### PR TITLE
🔗 :: (#114) recruitments companies paging 로직 구현

### DIFF
--- a/presentation/src/main/java/team/retum/jobis_android/contract/company/CompanyContract.kt
+++ b/presentation/src/main/java/team/retum/jobis_android/contract/company/CompanyContract.kt
@@ -13,7 +13,7 @@ sealed class CompanySideEffect : SideEffect {
 }
 
 data class CompanyState(
-    var companies: List<CompanyEntity> = mutableListOf(),
+    var companies: MutableList<CompanyEntity> = mutableListOf(),
     var page: Int = 1,
     var name: String? = null,
     var companyId: Long = 0,

--- a/presentation/src/main/java/team/retum/jobis_android/contract/recruitment/RecruitmentContract.kt
+++ b/presentation/src/main/java/team/retum/jobis_android/contract/recruitment/RecruitmentContract.kt
@@ -30,7 +30,7 @@ data class RecruitmentState(
         trainPay = 0,
         workHours = 0,
     ),
-    val recruitments: List<RecruitmentUiModel> = mutableListOf(),
+    val recruitments: MutableList<RecruitmentUiModel> = mutableListOf(),
 ): State
 
 sealed class RecruitmentSideEffect: SideEffect{

--- a/presentation/src/main/java/team/retum/jobis_android/feature/company/CompaniesScreen.kt
+++ b/presentation/src/main/java/team/retum/jobis_android/feature/company/CompaniesScreen.kt
@@ -1,5 +1,6 @@
 package team.retum.jobis_android.feature.company
 
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -15,9 +16,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,6 +63,16 @@ fun CompaniesScreen(
 
     val searchResultTextAlpha = if (state.name.isNullOrBlank()) 0f else 1f
 
+    val lazyListState = rememberLazyListState()
+    val visibleLastItemIndex = lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
+
+    LaunchedEffect(visibleLastItemIndex) {
+        if (visibleLastItemIndex == state.companies.lastIndex) {
+            companyViewModel.setPage()
+            companyViewModel.fetchCompanies()
+        }
+    }
+
     Box {
         Column(
             modifier = Modifier
@@ -88,6 +102,7 @@ fun CompaniesScreen(
                 Caption(text = state.name ?: "")
             }
             Companies(
+                lazyListState = lazyListState,
                 companies = companies,
                 navigateToCompanyDetails = navigateToCompanyDetails,
             )
@@ -117,10 +132,14 @@ private fun CompanyInput(
 
 @Composable
 private fun Companies(
+    lazyListState: LazyListState,
     companies: List<CompanyEntity>,
     navigateToCompanyDetails: (Long) -> Unit,
 ) {
-    LazyColumn(contentPadding = PaddingValues(vertical = 20.dp)) {
+    LazyColumn(
+        state = lazyListState,
+        contentPadding = PaddingValues(vertical = 20.dp),
+    ) {
         items(companies) { item ->
             Company(
                 name = item.name,

--- a/presentation/src/main/java/team/retum/jobis_android/feature/recruitment/RecruitmentsScreen.kt
+++ b/presentation/src/main/java/team/retum/jobis_android/feature/recruitment/RecruitmentsScreen.kt
@@ -110,7 +110,6 @@ internal fun RecruitmentsScreen(
                         setJobCode(jobCode)
                         setTechCode(techCode)
                         fetchRecruitments()
-                        setPage(1)
                     }
                     sheetState.hide()
                 }

--- a/presentation/src/main/java/team/retum/jobis_android/feature/recruitment/RecruitmentsScreen.kt
+++ b/presentation/src/main/java/team/retum/jobis_android/feature/recruitment/RecruitmentsScreen.kt
@@ -16,13 +16,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -60,6 +63,8 @@ import team.returm.jobisdesignsystem.util.JobisSize
 import team.returm.jobisdesignsystem.util.jobisClickable
 import java.text.DecimalFormat
 
+private const val PAGE_SIZE = 10
+
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 internal fun RecruitmentsScreen(
@@ -85,6 +90,16 @@ internal fun RecruitmentsScreen(
 
     val onNameChanged = { name: String ->
         recruitmentViewModel.setName(name)
+    }
+
+    val lazyListState = rememberLazyListState()
+    val visibleLastItemIndex = lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
+
+    LaunchedEffect(visibleLastItemIndex) {
+        if (visibleLastItemIndex == state.recruitments.lastIndex) {
+            recruitmentViewModel.setPage()
+            recruitmentViewModel.fetchRecruitments()
+        }
     }
 
     ModalBottomSheetLayout(
@@ -128,6 +143,7 @@ internal fun RecruitmentsScreen(
                     onKeywordChanged = onNameChanged,
                 )
                 Recruitments(
+                    lazyListState = lazyListState,
                     recruitmentUiModels = recruitments,
                     bookmarkViewModel = bookmarkViewModel,
                     putString = putString,
@@ -194,6 +210,7 @@ private fun RecruitmentInput(
 
 @Composable
 private fun Recruitments(
+    lazyListState: LazyListState,
     recruitmentUiModels: List<RecruitmentUiModel>,
     bookmarkViewModel: BookmarkViewModel,
     putString: (String, String) -> Unit,
@@ -214,6 +231,7 @@ private fun Recruitments(
     }
 
     LazyColumn(
+        state = lazyListState,
         verticalArrangement = Arrangement.spacedBy(16.dp),
         contentPadding = PaddingValues(vertical = 20.dp),
     ) {

--- a/presentation/src/main/java/team/retum/jobis_android/viewmodel/company/CompanyViewModel.kt
+++ b/presentation/src/main/java/team/retum/jobis_android/viewmodel/company/CompanyViewModel.kt
@@ -35,7 +35,7 @@ class CompanyViewModel @Inject constructor(
         fetchCompanies()
     }
 
-    private fun fetchCompanies() = intent {
+    internal fun fetchCompanies() = intent {
         viewModelScope.launch(Dispatchers.IO) {
             fetchCompaniesUseCase(
                 fetchCompaniesParam = FetchCompaniesParam(
@@ -103,18 +103,17 @@ class CompanyViewModel @Inject constructor(
     private fun setCompanies(
         companies: List<CompanyEntity>,
     ) = intent {
+        val currentCompanies = state.companies
+        currentCompanies.addAll(companies)
         reduce {
-            state.copy(companies = companies)
+            state.copy(companies = currentCompanies)
         }
     }
 
-    internal fun setPage(
-        page: Int,
-    ) = intent {
+    internal fun setPage() = intent {
+        val currentPage = state.page
         reduce {
-            state.copy(
-                page = page,
-            )
+            state.copy(page = currentPage + 1)
         }
     }
 

--- a/presentation/src/main/java/team/retum/jobis_android/viewmodel/recruitment/RecruitmentViewModel.kt
+++ b/presentation/src/main/java/team/retum/jobis_android/viewmodel/recruitment/RecruitmentViewModel.kt
@@ -160,10 +160,19 @@ internal class RecruitmentViewModel @Inject constructor(
     private fun setRecruitments(
         recruitments: List<RecruitmentUiModel>,
     ) = intent {
+        val currentRecruitments = state.recruitments
+        currentRecruitments.addAll(recruitments)
         reduce {
             state.copy(
-                recruitments = recruitments,
+                recruitments = currentRecruitments,
             )
+        }
+    }
+
+    internal fun setPage() = intent {
+        val currentPage = state.page
+        reduce {
+            state.copy(page = currentPage + 1)
         }
     }
 }

--- a/presentation/src/main/java/team/retum/jobis_android/viewmodel/recruitment/RecruitmentViewModel.kt
+++ b/presentation/src/main/java/team/retum/jobis_android/viewmodel/recruitment/RecruitmentViewModel.kt
@@ -105,16 +105,6 @@ internal class RecruitmentViewModel @Inject constructor(
         }
     }
 
-    internal fun setPage(
-        page: Int,
-    ) = intent {
-        reduce {
-            state.copy(
-                page = page,
-            )
-        }
-    }
-
     internal fun setJobCode(
         jobCode: Long?,
     ) = intent {


### PR DESCRIPTION
## 개요
> RecruitmentsScreen 및 CompaniesScreen의 list paging 로직을 구현하였습니다.

## 작업사항
- RecruitmentViewModel setPage state 함수 변경
- CompanyViewModel setPage state 함수 변경
- RecruitmentViewModel setRecruitment state 함수 변경
- CompanyViewModel setCompanies state 함수 변경

## 추가로 할 말
<b>Page Logic</b>
- 기존 page 인자를 전달받는 setPage함수에서 page 파라미터 제거
- setPage 함수 내부에서 현재 page state에 1을 증가하여 page state update
- screen에서 setPage() 함수를 호출함과 동시에 fetchRecruitments() || fetchCompanies() 함수를 호출
- setRecruitments() 및 setCompanies() 함수가 새로운 page에 해당하는 list 들을 전달받음
- 현재 리스트들을 변수에 복사한 뒤 새로운 리스트들을 추가
- 추가하여 만들어진 새 리스트를 state로 업데이트
