### PR TITLE
🔗 :: (#163) 검색 후 리스트 사라짐 버그 수정

### DIFF
--- a/presentation/src/main/kotlin/team/retum/jobis_android/feature/company/CompaniesScreen.kt
+++ b/presentation/src/main/kotlin/team/retum/jobis_android/feature/company/CompaniesScreen.kt
@@ -71,6 +71,7 @@ fun CompaniesScreen(
     }
 
     LaunchedEffect(Unit) {
+        companyViewModel.resetPage()
         companyViewModel.addCompaniesDummy()
     }
 

--- a/presentation/src/main/kotlin/team/retum/jobis_android/feature/recruitment/RecruitmentsScreen.kt
+++ b/presentation/src/main/kotlin/team/retum/jobis_android/feature/recruitment/RecruitmentsScreen.kt
@@ -73,6 +73,14 @@ internal fun RecruitmentsScreen(
     recruitmentViewModel: RecruitmentViewModel = hiltViewModel(),
     bookmarkViewModel: BookmarkViewModel = hiltViewModel(),
 ) {
+    LaunchedEffect(Unit) {
+        with(recruitmentViewModel){
+            resetPage()
+            fetchRecruitments()
+            fetchRecruitmentCount()
+        }
+    }
+
     val state by recruitmentViewModel.container.stateFlow.collectAsStateWithLifecycle()
 
     val sheetState = rememberModalBottomSheetState(ModalBottomSheetValue.Hidden)

--- a/presentation/src/main/kotlin/team/retum/jobis_android/viewmodel/company/CompanyViewModel.kt
+++ b/presentation/src/main/kotlin/team/retum/jobis_android/viewmodel/company/CompanyViewModel.kt
@@ -201,6 +201,10 @@ class CompanyViewModel @Inject constructor(
         }
     }
 
+    internal fun resetPage() = intent{
+        reduce { state.copy(page = 1) }
+    }
+
     private fun setReviewableCompanies(reviewableCompanies: List<ReviewableCompanyEntity>) =
         intent {
             reduce {

--- a/presentation/src/main/kotlin/team/retum/jobis_android/viewmodel/recruitment/RecruitmentViewModel.kt
+++ b/presentation/src/main/kotlin/team/retum/jobis_android/viewmodel/recruitment/RecruitmentViewModel.kt
@@ -31,11 +31,6 @@ internal class RecruitmentViewModel @Inject constructor(
 
     override val container = container<RecruitmentState, RecruitmentSideEffect>(RecruitmentState())
 
-    init {
-        fetchRecruitments()
-        fetchRecruitmentCount()
-    }
-
     private val _recruitments: SnapshotStateList<RecruitmentUiModel> = mutableStateListOf()
 
     internal fun addRecruitmentsDummy() = intent {
@@ -235,6 +230,12 @@ internal class RecruitmentViewModel @Inject constructor(
                 recruitments = _recruitments,
                 page = 1,
             )
+        }
+    }
+
+    internal fun resetPage() = intent{
+        reduce {
+            state.copy(page = 1)
         }
     }
 }


### PR DESCRIPTION
## 개요
> 검색 후 상세보기 이동 -> 다시 리스트 화면으로 돌아오면 리스트가 사라지는 버그를 수정했습니다.

## 문제사항
- 상세보기 이동 후 돌아오는 경우 page 3번부터 요청이 감
- 아마 Posts 맨 밑에서 호출되는 checkRecruitment(false) 때문인 것으로 추정

## 해결
- RecruitmentsScreen에 LaunchedEffect()를 사용하여 매 진입마다 page를 1로 초기화 하여 해결

## 추가 로 할 말
