### PR TITLE
🔗 :: (#165) 지원 버튼 클릭시 dialog dismiss

### DIFF
--- a/presentation/src/main/kotlin/team/retum/jobis_android/feature/application/RecruitmentApplicationDialog.kt
+++ b/presentation/src/main/kotlin/team/retum/jobis_android/feature/application/RecruitmentApplicationDialog.kt
@@ -88,7 +88,6 @@ internal fun RecruitmentApplicationDialog(
                         fileUrls = it.fileUrls,
                         urls = urls,
                     )
-                    applicationViewModel.applyCompany()
                 }
 
                 is FileSideEffect.FileLargeException -> {
@@ -128,7 +127,7 @@ internal fun RecruitmentApplicationDialog(
     val coroutineScope = rememberCoroutineScope()
 
     val onClickConfirmButton: () -> Unit = {
-        fileViewModel.uploadFile()
+        applicationViewModel.applyCompany()
         applicationViewModel.setButtonState(buttonState = false)
         coroutineScope.launch {
             delay(3000)
@@ -144,7 +143,6 @@ internal fun RecruitmentApplicationDialog(
                     uri = uri,
                 ),
             )
-            fileCount += 1
             applicationViewModel.setButtonState(fileCount > 0)
         }
     }
@@ -159,11 +157,14 @@ internal fun RecruitmentApplicationDialog(
                     uri = item.uri
                 }
                 addFile(uri)
+                fileCount += 1
             }
         } else {
             uri = result.data?.data
+            fileCount += 1
             addFile(uri)
         }
+        fileViewModel.uploadFile()
     }
 
     val onRemoveFile = { index: Int ->


### PR DESCRIPTION
## 개요
> 지원 버튼 클릭시 dialog를 dismiss 시키는 로직을 구현했습니다.

## 작업사항
- 파일 추가 할 때마다 파일 업로드 api 호출
- 지원하기 대기 시간 대폭 감소

## 추가 로 할 말
